### PR TITLE
Fix order of Geo Reference Image Frame Points.

### DIFF
--- a/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/klv/UasDataLinkSet.java
+++ b/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/klv/UasDataLinkSet.java
@@ -397,24 +397,24 @@ public class UasDataLinkSet extends AbstractDataSet {
                         valuesMap.put(tag, frameCenterLongitude);
                         break;
 
-                    case 0x1A: // "Offset Corner Latitude Point 1", "Frame latitude offset for upper left corner", "deg"
-                    case 0x1C: // "Offset Corner Latitude Point 2", "Frame latitude offset for upper right corner", "deg"
-                    case 0x1E: // "Offset Corner Latitude Point 3", "Frame latitude offset for lower right corner", "deg"
+                    case 0x1A: // "Offset Corner Latitude Point 1", "Frame latitude offset for upper right corner", "deg"
+                    case 0x1C: // "Offset Corner Latitude Point 2", "Frame latitude offset for lower right corner", "deg"
+                    case 0x1E: // "Offset Corner Latitude Point 3", "Frame latitude offset for lower left corner", "deg"
                         valuesMap.put(tag, convertToDouble((short) value, 0.15, 65534.0, frameCenterLatitude));
                         break;
 
-                    case 0x1B: // "Offset Corner Longitude Point 1", "Frame longitude offset for upper left corner", "deg"
-                    case 0x1D: // "Offset Corner Longitude Point 2", "Frame longitude offset for upper right corner", "deg"
-                    case 0x1F: // "Offset Corner Longitude Point 3", "Frame longitude offset for lower right corner", "deg"
+                    case 0x1B: // "Offset Corner Longitude Point 1", "Frame longitude offset for upper right corner", "deg"
+                    case 0x1D: // "Offset Corner Longitude Point 2", "Frame longitude offset for lower right corner", "deg"
+                    case 0x1F: // "Offset Corner Longitude Point 3", "Frame longitude offset for lower left corner", "deg"
                         valuesMap.put(tag, convertToDouble((short) value, 0.15, 65534.0, frameCenterLongitude));
                         break;
 
-                    case 0x20: // "Offset Corner Latitude Point 4", "Frame latitude offset for lower left corner", "deg"
+                    case 0x20: // "Offset Corner Latitude Point 4", "Frame latitude offset for upper left corner", "deg"
                         valuesMap.put(tag, convertToDouble((short) value, 0.15, 65534.0, frameCenterLatitude));
                         frameCenterLatitude = 0.0;
                         break;
 
-                    case 0x21: // "Offset Corner Longitude Point 4", "Frame longitude offset for lower left corner", "deg"
+                    case 0x21: // "Offset Corner Longitude Point 4", "Frame longitude offset for upper left corner", "deg"
                         valuesMap.put(tag, convertToDouble((short) value, 0.15, 65534.0, frameCenterLongitude));
                         frameCenterLongitude = 0.0;
                         break;

--- a/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/outputs/GeoRefImageFrame.java
+++ b/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/outputs/GeoRefImageFrame.java
@@ -111,35 +111,35 @@ public class GeoRefImageFrame extends UasOutput {
                     dataBlock.setDoubleValue(5, (Double) value);
                     break;
     
-                case 0x1A: // "Offset Corner Latitude Point 1", "Frame latitude offset for upper left corner", "deg"
+                case 0x1A: // "Offset Corner Latitude Point 1", "Frame latitude offset for upper right corner", "deg"
                     dataBlock.setDoubleValue(6, (Double) value);
                     break;
     
-                case 0x1B: // "Offset Corner Longitude Point 1", "Frame longitude offset for upper left corner", "deg"
+                case 0x1B: // "Offset Corner Longitude Point 1", "Frame longitude offset for upper right corner", "deg"
                     dataBlock.setDoubleValue(7, (Double) value);
                     break;
     
-                case 0x1C: // "Offset Corner Latitude Point 2", "Frame latitude offset for upper right corner", "deg"
+                case 0x1C: // "Offset Corner Latitude Point 2", "Frame latitude offset for lower right corner", "deg"
                     dataBlock.setDoubleValue(8, (Double) value);
                     break;
     
-                case 0x1D: // "Offset Corner Longitude Point 2", "Frame longitude offset for upper right corner", "deg"
+                case 0x1D: // "Offset Corner Longitude Point 2", "Frame longitude offset for lower right corner", "deg"
                     dataBlock.setDoubleValue(9, (Double) value);
                     break;
     
-                case 0x1E: // "Offset Corner Latitude Point 3", "Frame latitude offset for lower right corner", "deg"
+                case 0x1E: // "Offset Corner Latitude Point 3", "Frame latitude offset for lower left corner", "deg"
                     dataBlock.setDoubleValue(10, (Double) value);
                     break;
     
-                case 0x1F: // "Offset Corner Longitude Point 3", "Frame longitude offset for lower right corner", "deg"
+                case 0x1F: // "Offset Corner Longitude Point 3", "Frame longitude offset for lower left corner", "deg"
                     dataBlock.setDoubleValue(11, (Double) value);
                     break;
     
-                case 0x20: // "Offset Corner Latitude Point 4", "Frame latitude offset for lower left corner", "deg"
+                case 0x20: // "Offset Corner Latitude Point 4", "Frame latitude offset for upper left corner", "deg"
                     dataBlock.setDoubleValue(12, (Double) value);
                     break;
     
-                case 0x21: // "Offset Corner Longitude Point 4", "Frame longitude offset for lower left corner", "deg"
+                case 0x21: // "Offset Corner Longitude Point 4", "Frame longitude offset for upper left corner", "deg"
                     dataBlock.setDoubleValue(13, (Double) value);
                     break;
     

--- a/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/outputs/UasHelper.java
+++ b/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/outputs/UasHelper.java
@@ -103,14 +103,14 @@ public class UasHelper extends GeoPosHelper {
                         .definition(SWEHelper.getPropertyUri("FrameCenterElevation"))
                         .uomCode("m")
                         .build())
-                .addField("ulc",
-                        newLocationVectorLatLon(SWEHelper.getPropertyUri("FrameUpperLeftCorner")))
                 .addField("urc",
                         newLocationVectorLatLon(SWEHelper.getPropertyUri("FrameUpperRightCorner")))
-                .addField("llc",
-                        newLocationVectorLatLon(SWEHelper.getPropertyUri("FrameLowerLeftCorner")))
                 .addField("lrc",
                         newLocationVectorLatLon(SWEHelper.getPropertyUri("FrameLowerRightCorner")))
+                .addField("llc",
+                        newLocationVectorLatLon(SWEHelper.getPropertyUri("FrameLowerLeftCorner")))
+                .addField("ulc",
+                        newLocationVectorLatLon(SWEHelper.getPropertyUri("FrameUpperLeftCorner")))
                 .build();
     }
 


### PR DESCRIPTION
Fix issue with Georeferenced Image Frame Points being out of order, correct order is URC->LRC->LLC->ULC.