### PR TITLE
sensorhub-process-geoloc uses old SWEConstants ECEF constant

### DIFF
--- a/processing/sensorhub-process-geoloc/src/main/java/org/sensorhub/process/geoloc/RayIntersectEllipsoid.java
+++ b/processing/sensorhub-process-geoloc/src/main/java/org/sensorhub/process/geoloc/RayIntersectEllipsoid.java
@@ -72,7 +72,7 @@ public class RayIntersectEllipsoid extends ExecutableProcessImpl
         inputData.add("rayOrigin", rayOrigin);
         
         // ray direction in reference frame (ECEF by default)
-        rayDirection = sweHelper.newUnitVectorXYZ(null, SWEConstants.REF_FRAME_ECEF);
+        rayDirection = sweHelper.newUnitVectorXYZ(null, SWEConstants.REF_FRAME_WGS84_ECEF);
         inputData.add("rayDirection", rayDirection);
         
         //// PARAMETERS ////


### PR DESCRIPTION
[A commit to lib-ogc](https://github.com/sensiasoft/lib-ogc/commit/4dbefefa9dce0d9569f1d2e1ec7caa4d583ab639) broke the geoloc process in osh-addons. This pull request fixes geoloc.