### PR TITLE
MISB UAS driver: specify server connection as single String

### DIFF
--- a/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/UasSensor.java
+++ b/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/UasSensor.java
@@ -63,15 +63,16 @@ public class UasSensor extends AbstractSensorModule<UasConfig> {
         this.executor = Executors.newSingleThreadExecutor();
         boolean streamOpened = false;
 
-        // Get the stream processor
-        if ((null != config.connection.transportStreamPath) && (!config.connection.transportStreamPath.isEmpty())) {
-
+        // Initialize the MPEG transport stream processor from the source named in the configuration.
+        // If neither the file source nor a connection string is specified, throw an exception so the user knows that
+        // they have to provide at least one of them.
+        if ((null != config.connection.transportStreamPath) && (!config.connection.transportStreamPath.isBlank())) {
             Asserts.checkArgument(config.connection.fps >= 0, "FPS must be >= 0");
             mpegTsProcessor = new MpegTsProcessor(config.connection.transportStreamPath, config.connection.fps, config.connection.loop);
-
+        } else if ((null != config.connection.connectionString) && (!config.connection.connectionString.isBlank())) {
+            mpegTsProcessor = new MpegTsProcessor(config.connection.connectionString);
         } else {
-
-            mpegTsProcessor = new MpegTsProcessor(config.connection.serverIpAddress + ":" + config.connection.serverIpPort);
+        	throw new SensorHubException("Either the input file path or the connection string must be set");
         }
 
         // Attempt to open the stream

--- a/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/config/Connection.java
+++ b/sensors/aviation/sensorhub-driver-misb-uas/src/main/java/org/sensorhub/impl/sensor/uas/config/Connection.java
@@ -35,10 +35,6 @@ public class Connection {
     @DisplayInfo(desc = "Continuously loop video playback (only available when reading from file).")
     public boolean loop = false;
 
-    @DisplayInfo(label = "Server Ip", desc = "Server IP address of MISB STANAG 4609 MPEG-TS data to be streamed")
-    @DisplayInfo.FieldType(value = DisplayInfo.FieldType.Type.REMOTE_ADDRESS)
-    public String serverIpAddress;
-
-    @DisplayInfo(label = "Port", desc = "Server IP port of MISB STANAG 4609 MPEG-TS data to be streamed")
-    public int serverIpPort;
+    @DisplayInfo(label = "Connection String", desc = "Connection string that the driver will pass to ffmpeg to connect to the MISB STANAG 4609 MPEG-TS stream. This value is ignored if an input file path is also set in the configuration. See https://www.ffmpeg.org/ffmpeg-protocols.html#Protocols for details of allowed values.")
+    public String connectionString;
 }


### PR DESCRIPTION
Change MISB UAS driver configuration so that the connection is defined by a URI(-ish) String, instead of server and port. This allows for more flexibility since it'll be passed directly to ffmpeg, which supports a wide variety of connection strings.

#47
