### PR TITLE
Use correct Activator path for SonyVB600

### DIFF
--- a/sensors/video/sensorhub-driver-sony-vb600/build.gradle
+++ b/sensors/video/sensorhub-driver-sony-vb600/build.gradle
@@ -21,7 +21,7 @@ test {
 osgi {
     manifest {
         attributes("Bundle-Vendor": "Botts Innovative Research, Inc.")
-        attributes("Bundle-Activator": "org.sensorhub.impl.sensor.sony.vb600.vb600Activator")
+        attributes("Bundle-Activator": "org.sensorhub.impl.sensor.sony.vb600.VB600Activator")
     }
 }
 


### PR DESCRIPTION
Sony cam fails to build with wrong OSGi activator path. This updates path with correct filename