### PR TITLE
Upgrade org.json:json dependency in OAuth2.0

### DIFF
--- a/security/sensorhub-security-oauth/build.gradle
+++ b/security/sensorhub-security-oauth/build.gradle
@@ -4,9 +4,12 @@ version = '1.0.0'
 
 dependencies {
   implementation 'org.sensorhub:sensorhub-core:' + oshCoreVersion
-  embeddedImpl 'org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.1'
+  embeddedImpl 'org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2'
   embeddedImpl 'com.auth0:java-jwt:4.4.0'
   embeddedImpl 'com.auth0:jwks-rsa:0.22.1'
+  // Force upgrade on dependency to address secuirty vulnerabilities
+  // This lib is required by org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2
+  embeddedImpl 'org.json:json:20240303'
 }
 
 // add info to OSGi manifest


### PR DESCRIPTION
Force the upgrade of a dependency to address transitive security vulnerabilities.