### PR TITLE
Parse payload properly to get user info

### DIFF
--- a/security/sensorhub-security-oauth/src/main/java/org/sensorhub/impl/security/oauth/OAuthAuthenticator.java
+++ b/security/sensorhub-security-oauth/src/main/java/org/sensorhub/impl/security/oauth/OAuthAuthenticator.java
@@ -345,7 +345,7 @@ public class OAuthAuthenticator extends LoginAuthenticator {
 
                             decodedJWT = verifier.verify(clientCredentialsToken);
 
-                            String payload = decodedJWT.getPayload();
+                            String payload = new String(decoder.decode(decodedJWT.getPayload()));
 
                             log.debug("Client Token Payload = {}", payload);
 


### PR DESCRIPTION
The JWT Token is comprised of 3 Base64 encoded values.  The header was decoded but the payload was not so logic was failing to retrieve user information from the token necessary for authenticating in the Client Credentials Flow (bearer tokens).