### PR TITLE
Fix client credentials flow for OAuth2.0

### DIFF
--- a/security/sensorhub-security-oauth/build.gradle
+++ b/security/sensorhub-security-oauth/build.gradle
@@ -1,6 +1,6 @@
 description = 'OAuth2 Authentication'
 ext.details = 'Provides federated authentication through OAuth2 providers such as Google, Twitter, etc.'
-version = '1.0.0'
+version = '1.0.1'
 
 dependencies {
   implementation 'org.sensorhub:sensorhub-core:' + oshCoreVersion

--- a/security/sensorhub-security-oauth/src/main/java/org/sensorhub/impl/security/oauth/OAuthAuthenticator.java
+++ b/security/sensorhub-security-oauth/src/main/java/org/sensorhub/impl/security/oauth/OAuthAuthenticator.java
@@ -270,30 +270,7 @@ public class OAuthAuthenticator extends LoginAuthenticator {
 
                                 String kid = parseKidFromJson(headerData);
 
-                                Jwk jwk = null;
-
-                                try {
-                                    // Attempt to retrieve the JWK from the cache
-                                    jwk = jwkProvider.get(kid);
-
-                                } catch (JwkException e) {
-
-                                  log.info("JWK provider returned an error: {}", e.getMessage());
-                                }
-
-                                // If it does not exist, it is because it has expired and needs to be reset
-                                if (jwk == null) {
-
-                                    log.info("Creating a new JWK provider that will expire in {} minutes", config.bearerTokenConfig.cacheDuration);
-
-                                    this.jwkProvider =
-                                            new JwkProviderBuilder(new URL(config.bearerTokenConfig.jwksUri))
-                                                    .cached(config.bearerTokenConfig.cacheSize,
-                                                            Duration.of(config.bearerTokenConfig.cacheDuration, ChronoUnit.MINUTES))
-                                                    .build();
-
-                                    jwk = jwkProvider.get(kid);
-                                }
+                                Jwk jwk = jwkProvider.get(kid);
 
                                 RSAPublicKey publicKey = (RSAPublicKey) jwk.getPublicKey();
                                 Algorithm algorithm = Algorithm.RSA256(publicKey);


### PR DESCRIPTION
Update client credentials flow to work when access token not received but bearer token is received and available in auth header.

In essence, when receiving a bearer token for client credentials flow, user info must be extracted from this token that is provided within the auth header of the request.  The previous method attempted the same solution but failed in that it was reading the access token as it too is of type "bearer" and thus was treating the access token as the client credentials token circumventing the ability to read the id_token from the OAuth response when a user log in operation was being transacted in some keycloak enabled environments.