### PR TITLE
Fix H264 stream, inject sps and pps data on keyframe with config opt

### DIFF
--- a/sensors/video/sensorhub-driver-ffmpeg/README.md
+++ b/sensors/video/sensorhub-driver-ffmpeg/README.md
@@ -42,6 +42,9 @@ When added to an OpenSensorHub node, the driver has the following configuration 
     - **Loop:**
       When **Connection String** is a file,
       this indicates that the data should be looped to create a continuous stream of data.
+    - **Inject Extradata:**
+      Only for H264. When checked, injects Annex B extradata into the video stream before every keyframe. 
+      This is necessary for late-join decoders (those that receive live data from the driver after the driver has started).
 
 - **Position:**
     - **Location:** (Optional)

--- a/sensors/video/sensorhub-driver-ffmpeg/build.gradle
+++ b/sensors/video/sensorhub-driver-ffmpeg/build.gradle
@@ -1,6 +1,6 @@
 description = 'FFMPEG Video Driver'
 ext.details = "Driver for connecting to ffmpeg capable video streams"
-version = '1.0.0'
+version = '1.1.0'
 
 // To build in entire java cv platform of projects use
 //    implementation('org.bytedeco:javacv-platform:1.5.2')

--- a/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensor.java
+++ b/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensor.java
@@ -208,6 +208,7 @@ public class FFMPEGSensor extends AbstractSensorModule<FFMPEGConfig> {
                 logger.info("Opening network stream");
                 mpegTsProcessor = new MpegTsProcessor(config.connection.connectionString);
             }
+            mpegTsProcessor.setInjectVideoExtradata(config.connection.injectExtradata);
         }
 
         if (mpegTsProcessor.isStreamOpened()) {

--- a/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/config/Connection.java
+++ b/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/config/Connection.java
@@ -37,4 +37,7 @@ public class Connection {
      */
     @DisplayInfo(desc = "Continuously loop video playback. Only used when reading from file.")
     public boolean loop = false;
+
+    @DisplayInfo(label = "Inject Extradata for Streaming", desc = "Injects extradata into the video stream. Set true if this driver is being used to output a live video stream for late-join decoders.")
+    public boolean injectExtradata = true;
 }

--- a/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/mpegts/MpegTsProcessor.java
+++ b/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/mpegts/MpegTsProcessor.java
@@ -331,6 +331,10 @@ public class MpegTsProcessor extends Thread {
         audioStreamContext.setDataBufferListener(audioDataBufferListener);
     }
 
+    public void setInjectVideoExtradata(boolean injectVideoExtradata) {
+        videoStreamContext.setInjectingExtradata(injectVideoExtradata);
+    }
+
     /**
      * Registers a data buffer listener to call if clients are interested in demuxed data buffers
      *


### PR DESCRIPTION
Same as the fix to the reverted driver. Whenever the "Inject Extradata for Streaming" config option is enabled, the driver adds extradata before every keyframe (H264 video only). Fixes H264 streams and mp4 files not working.