### PR TITLE
Fix ONVIF driver crashes on continuous-only PTZ cameras

### DIFF
--- a/sensors/video/sensorhub-driver-onvif/src/main/java/org/sensorhub/impl/sensor/onvif/OnvifCameraDriver.java
+++ b/sensors/video/sensorhub-driver-onvif/src/main/java/org/sensorhub/impl/sensor/onvif/OnvifCameraDriver.java
@@ -228,7 +228,10 @@ public class OnvifCameraDriver extends AbstractSensorModule<OnvifCameraConfig>
         }
 
         TreeSet<URL> temp = (TreeSet<URL>) OnvifDiscovery.discoverOnvifURLs();
-        config.networkConfig.autoRemoteHost.clear();
+        if (config.networkConfig.autoRemoteHost == null)
+            config.networkConfig.autoRemoteHost = new TreeSet<>();
+        else
+            config.networkConfig.autoRemoteHost.clear();
         for (URL url : temp)
             config.networkConfig.autoRemoteHost.add(url.toString());
     }
@@ -570,8 +573,8 @@ public class OnvifCameraDriver extends AbstractSensorModule<OnvifCameraConfig>
     protected void openStreamVisual() throws SensorHubException{
         if (mpegTsProcessor == null) {
             mpegTsProcessor = new MpegTsProcessor(visualConnectionString);
-            // Remove the following line if causing an error. Part of a separate ffmpeg mod.
-            //mpegTsProcessor.setAvOption("transport", streamTransport);
+            // Inject SPS/PPS before keyframes so late-joining decoders (e.g. WebCodecs) can initialize
+            mpegTsProcessor.setInjectVideoExtradata(true);
 
             // Initialize the MPEG transport stream processor from the source named in the configuration.
             if (mpegTsProcessor.openStream()) {

--- a/sensors/video/sensorhub-driver-onvif/src/main/java/org/sensorhub/impl/sensor/onvif/OnvifPtzControl.java
+++ b/sensors/video/sensorhub-driver-onvif/src/main/java/org/sensorhub/impl/sensor/onvif/OnvifPtzControl.java
@@ -217,17 +217,21 @@ public class OnvifPtzControl extends AbstractSensorControl<OnvifCameraDriver>
 		commandData.addItem(presetRemove.getName(), presetRemove);
 
 		// Remove components for commands that are not supported
+		boolean absolutePtRemoved = false;
 		if (devicePtzConfig.getDefaultAbsolutePantTiltPositionSpace() == null) {
 			// Remove absolute PTZ
 			commandData.removeComponent(VideoCamHelper.TASKING_PAN);
 			commandData.removeComponent(VideoCamHelper.TASKING_TILT);
 			commandData.removeComponent(VideoCamHelper.TASKING_PTZ_POS);
+			absolutePtRemoved = true;
 			log.debug("Removed absolute pt");
 		}
 		if (devicePtzConfig.getDefaultAbsoluteZoomPositionSpace() == null) {
 			commandData.removeComponent(VideoCamHelper.TASKING_ZOOM);
-			// Zoom is nested in the ptz pos item
-			commandData.getItem(VideoCamHelper.TASKING_PTZ_POS).removeComponent(VideoCamHelper.TASKING_ZOOM);
+			// Zoom is nested in the ptz pos item — only remove if ptzPos still exists
+			if (!absolutePtRemoved) {
+				commandData.getItem(VideoCamHelper.TASKING_PTZ_POS).removeComponent(VideoCamHelper.TASKING_ZOOM);
+			}
 			log.debug("Removed absolute z");
 		}
 		if (devicePtzConfig.getDefaultRelativePanTiltTranslationSpace() == null
@@ -299,10 +303,13 @@ public class OnvifPtzControl extends AbstractSensorControl<OnvifCameraDriver>
 			PTZVector position = null;
 			try {
 				PTZStatus status = ptz.getStatus(ptzProfile.getToken());
-				position = status.getPosition();
+				if (status != null)
+					position = status.getPosition();
 			} catch (Exception e) {
-				position = new PTZVector();
+				// status not available
 			}
+			if (position == null)
+				position = new PTZVector();
 
 			// Note: Some tasking is not supported for certain cameras
 			// ABSOLUTE PAN


### PR DESCRIPTION
## Summary

Fixes four bugs in the ONVIF driver that cause crashes or failures when used with cameras that only support continuous PTZ (no absolute/relative), such as Reolink models.

- **Fix `IllegalArgumentException` on `ptzPos` access after removal**: When a camera lacks absolute pan/tilt, the `ptzPos` component is removed from `commandData`. The subsequent zoom-removal code then crashes trying to access the already-removed item. Added a guard flag (`absolutePtRemoved`) to skip the nested removal.

- **Fix `NullPointerException` in `execCommand` when position is null**: Some cameras return `null` from `getStatus()` or `getPosition()` rather than throwing an exception. Added null checks with a fallback to an empty `PTZVector`.

- **Fix `NullPointerException` on `autoRemoteHost.clear()` during init**: GSON deserializes missing/null JSON fields as `null`, overriding Java field initializers. Added a null-check before `clear()`, initializing with `new TreeSet<>()` when null.

- **Enable H.264 extradata injection for WebCodecs compatibility**: Calls `mpegTsProcessor.setInjectVideoExtradata(true)` so SPS/PPS NAL units are prepended before keyframes. Without this, browser-based viewers using the WebCodecs `VideoDecoder` API cannot decode the H.264 stream when joining mid-stream (they require a keyframe with SPS/PPS to initialize).

## Test plan

- [x] Tested with Reolink RLC-823A (continuous-only PTZ, H.264)
- [x] Camera initializes without `IllegalArgumentException`
- [x] PTZ continuous move commands work correctly
- [x] H.264 video streams to OSH Viewer via WebCodecs without `DataError`
- [x] Audio stream initializes alongside video