### PR TITLE
RTMP Sensor Driver

### DIFF
--- a/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/mpegts/MpegTsProcessor.java
+++ b/sensors/video/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/mpegts/MpegTsProcessor.java
@@ -14,12 +14,14 @@ package org.sensorhub.mpegts;
 import org.bytedeco.ffmpeg.avcodec.AVCodecParameters;
 import org.bytedeco.ffmpeg.avcodec.AVPacket;
 import org.bytedeco.ffmpeg.avformat.AVFormatContext;
+import org.bytedeco.ffmpeg.avformat.AVIOInterruptCB;
 import org.bytedeco.ffmpeg.avformat.AVInputFormat;
 import org.bytedeco.ffmpeg.avutil.AVDictionary;
 import org.bytedeco.ffmpeg.avutil.AVRational;
 import org.bytedeco.ffmpeg.global.avcodec;
 import org.bytedeco.ffmpeg.global.avformat;
 import org.bytedeco.ffmpeg.global.avutil;
+import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,8 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.bytedeco.ffmpeg.global.avdevice.avdevice_register_all;
-import static org.bytedeco.ffmpeg.global.avformat.av_find_input_format;
-import static org.bytedeco.ffmpeg.global.avformat.av_read_frame;
+import static org.bytedeco.ffmpeg.global.avformat.*;
 
 /**
  * The class provides a wrapper to bytedeco.org JavaCpp-Platform.
@@ -97,6 +98,13 @@ public class MpegTsProcessor extends Thread {
      * Context used by underlying FFmpeg library to decode stream.
      */
     private AVFormatContext avFormatContext;
+
+    /**
+     * Callbacks allow some blocking AVFormatContext operations to terminate early on
+     * stream close. These are global for GC purposes; do not directly modify.
+     */
+    private AVIOInterruptCB.Callback_Pointer callbackPointer;
+    private AVIOInterruptCB interruptCallback;
 
     /**
      * Flag indicating if processing of the transport stream should be terminated.
@@ -186,7 +194,17 @@ public class MpegTsProcessor extends Thread {
         avformat.avformat_network_init();
 
         // Create a new AV Format Context for I/O
-        avFormatContext = new AVFormatContext(null);
+        avFormatContext = avformat_alloc_context();
+
+        // Allow for context to be interrupted after attempt to stop stream
+        interruptCallback = avFormatContext.interrupt_callback();
+        callbackPointer = new AVIOInterruptCB.Callback_Pointer() {
+            @Override
+            public int call(Pointer opaque) {
+                return terminateProcessing.get() ? 1 : 0;
+            }
+        };
+        interruptCallback.callback(callbackPointer);
 
         AVInputFormat inputFormat = null;
 
@@ -526,11 +544,8 @@ public class MpegTsProcessor extends Thread {
      */
     public void stopProcessingStream() {
         logger.debug("stopProcessingStream");
-
-        if (streamOpened) {
-            loop = false;
-            terminateProcessing.set(true);
-        }
+        loop = false;
+        terminateProcessing.set(true);
     }
 
     /**

--- a/sensors/video/sensorhub-driver-rtmp/README.md
+++ b/sensors/video/sensorhub-driver-rtmp/README.md
@@ -1,0 +1,7 @@
+### Axis PTZ (Pan-Tilt-Zoom) Video Camera
+
+OSH sensor adaptor supporting output (video and PTZ settings) and tasking (camera and PTZ) for Axis cameras.
+
+This driver depends on the following modules at runtime:
+  * sensorhub-driver-rtpcam
+  * sensorhub-driver-videocam

--- a/sensors/video/sensorhub-driver-rtmp/README.md
+++ b/sensors/video/sensorhub-driver-rtmp/README.md
@@ -1,7 +1,38 @@
-### Axis PTZ (Pan-Tilt-Zoom) Video Camera
+# FFmpeg RTMP Driver
 
-OSH sensor adaptor supporting output (video and PTZ settings) and tasking (camera and PTZ) for Axis cameras.
+OSH sensor driver using FFmpeg to listen to RTMP streams.
 
 This driver depends on the following modules at runtime:
-  * sensorhub-driver-rtpcam
-  * sensorhub-driver-videocam
+* sensorhub-driver-ffmpeg
+
+## Config
+
+### Connection
+
+* **Host**
+  - RTMP server host 
+    - **UNSPECIFIED**: listen for remote connections.
+    - **LOCALHOST**: listen for local connections.
+    - **DOCKER_INTERNAL**: listen for connections inside a docker container.
+* **Port**
+  - RTMP server port
+    - 1935 is the default port for RTMP.
+    - Any port may be used as long as it is not in use by another listener (or any other application).
+      - RTMP sensor driver modules track ports in use. To release ownership of a port, STOP the module.
+
+## Usage
+
+### Initialization
+
+<p>To initialize the driver, provide a unique serial number in the configuration.
+In connection, set the host and provide an unused port. Once initialized, other RTMP sensor driver modules cannot
+use the same port. 
+<br><br><strong>Stop</strong> the module to free the port.</p>
+
+### Listening
+
+<p>Once initialized, start the module to begin listening for RTMP connections. <strong>After</strong> the driver
+is started, begin publishing the RTMP stream. 
+<br><br><strong>Note</strong>: The module does NOT attempt to validate the 
+username, password, RTMP app, or RTMP playpath. Only the host and port need to match.</p>
+

--- a/sensors/video/sensorhub-driver-rtmp/build.gradle
+++ b/sensors/video/sensorhub-driver-rtmp/build.gradle
@@ -1,0 +1,28 @@
+description = 'RTMP Video Driver'
+ext.details = 'Driver to listen for and demux RTMP video streams'
+version = '1.0.0'
+
+dependencies {
+  implementation 'org.sensorhub:sensorhub-core:' + oshCoreVersion
+  implementation project(':sensorhub-driver-ffmpeg')
+}
+
+// add info to OSGi manifest
+osgi {
+  manifest {
+    attributes('Bundle-Vendor': 'Botts Innovative Research, Inc.')
+    attributes('Bundle-Activator': 'org.sensorhub.impl.sensor.rtmp.Activator')
+  }
+}
+
+// add info to maven pom
+ext.pom >>= {
+  developers {
+    developer {
+      id 'kyle-fitzp'
+      name 'Kyle Fitzpatrick'
+      organization 'GeoRobotix Inc.'
+      organizationUrl 'http://www.georobotix.com'
+    }
+  }
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/Activator.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/Activator.java
@@ -1,0 +1,13 @@
+package org.sensorhub.impl.sensor.rtmp;
+
+import org.osgi.framework.BundleActivator;
+import org.sensorhub.utils.OshBundleActivator;
+
+
+/*
+ * Needed to expose java services as OSGi services
+ */
+public class Activator extends OshBundleActivator implements BundleActivator
+{
+
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDescriptor.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDescriptor.java
@@ -1,0 +1,41 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+
+The contents of this file are subject to the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one
+at http://mozilla.org/MPL/2.0/.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+for the specific language governing rights and limitations under the License.
+ 
+The Initial Developer is Botts Innovative Research Inc.. Portions created by the Initial
+Developer are Copyright (C) 2014 the Initial Developer. All Rights Reserved.
+ 
+******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.sensor.rtmp;
+
+import org.sensorhub.api.module.IModule;
+import org.sensorhub.api.module.IModuleProvider;
+import org.sensorhub.api.module.ModuleConfig;
+import org.sensorhub.impl.module.JarModuleProvider;
+import org.sensorhub.impl.sensor.rtmp.config.RtmpConfig;
+
+
+public class RtmpDescriptor extends JarModuleProvider implements IModuleProvider
+{
+
+	@Override
+	public Class<? extends IModule<?>> getModuleClass()
+	{
+		return RtmpDriver.class;
+	}
+
+	
+	@Override
+	public Class<? extends ModuleConfig> getModuleConfigClass()
+	{
+	       return RtmpConfig.class;
+	}
+
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
@@ -8,6 +8,7 @@ import org.sensorhub.impl.sensor.rtmp.config.HostType;
 import org.sensorhub.impl.sensor.rtmp.config.RtmpConfig;
 import org.sensorhub.mpegts.MpegTsProcessor;
 
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -32,12 +33,18 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
     protected void doInit() throws SensorHubException {
         super.doInit();
 
+        if (getUniqueIdentifier() == null) {
+            generateUniqueID("urn:osh:sensor:rtmp:", config.serialNumber);
+            generateXmlID("RTMP_", config.serialNumber);
+        }
+
         urlArbiter.removeConnection(connectionUrl);
 
         setConnectionUrl();
 
-        if (!urlArbiter.addConnection(connectionUrl)) {
-            throw new SensorException("RTMP url already in use: " + connectionUrl);
+        String moduleUid;
+        if ((moduleUid = urlArbiter.addConnection(connectionUrl, this.getUniqueIdentifier())) != null) {
+            throw new SensorException("RTMP url already in use by module: " + moduleUid);
         }
 
         createMpegTsProcessor();

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
@@ -1,0 +1,264 @@
+package org.sensorhub.impl.sensor.rtmp;
+import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.sensor.SensorException;
+import org.sensorhub.impl.sensor.AbstractSensorModule;
+import org.sensorhub.impl.sensor.ffmpeg.outputs.AudioOutput;
+import org.sensorhub.impl.sensor.ffmpeg.outputs.VideoOutput;
+import org.sensorhub.impl.sensor.rtmp.config.HostType;
+import org.sensorhub.impl.sensor.rtmp.config.RtmpConfig;
+import org.sensorhub.mpegts.MpegTsProcessor;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
+    private static final RtmpUrlArbiter urlArbiter = new RtmpUrlArbiter();
+    private ExecutorService executorService;
+    private ExecutorService videoExecutorService;
+    private ExecutorService audioExecutorService;
+    private ScheduledExecutorService heartbeatExecutorService;
+
+    final AtomicReference<MpegTsProcessor> mpegTsProcessor = new AtomicReference<>();
+    final AtomicReference<VideoOutput<RtmpDriver>> videoOutput = new AtomicReference<>();
+    final AtomicReference<AudioOutput<RtmpDriver>> audioOutput = new AtomicReference<>();
+    String connectionUrl = "";
+    volatile boolean hasConnected = false;
+
+
+    @Override
+    protected void doInit() throws SensorHubException {
+        super.doInit();
+
+        urlArbiter.removeConnection(connectionUrl);
+
+        setConnectionUrl();
+
+        if (!urlArbiter.addConnection(connectionUrl)) {
+            throw new SensorException("RTMP url already in use: " + connectionUrl);
+        }
+
+        createMpegTsProcessor();
+    }
+
+    private void createMpegTsProcessor() {
+        String commandLineArgs = "-timeout 0 -listen 1";
+
+        var mpegts = new MpegTsProcessor(connectionUrl, commandLineArgs);
+        mpegts.setInjectVideoExtradata(true);
+        mpegTsProcessor.set(mpegts);
+    }
+
+    private void setConnectionUrl() throws SensorException {
+        var connectionConfig = config.connectionConfig;
+        StringBuilder sb = new StringBuilder("rtmp://");
+
+        if (connectionConfig.host == HostType.OVERRIDE) {
+            if (connectionConfig.hostOverride == null || connectionConfig.hostOverride.isBlank()) {
+                throw new SensorException("Domain override is not set");
+            }
+            sb.append(connectionConfig.hostOverride);
+        } else {
+            sb.append(connectionConfig.host.host);
+        }
+
+        sb.append(":").append(connectionConfig.port);
+
+        if (connectionConfig.path != null && !connectionConfig.path.isBlank()) {
+            if (!connectionConfig.path.startsWith("/")) {
+                sb.append("/");
+            }
+            sb.append(connectionConfig.path.trim());
+        }
+
+        connectionUrl = sb.toString();
+    }
+
+
+    @Override
+    protected void afterStart() throws SensorHubException {
+        super.afterStart();
+        //stopStream();
+        hasConnected = false;
+
+        if (mpegTsProcessor.get() == null) {
+            createMpegTsProcessor();
+        } else if (mpegTsProcessor.get().getState() != Thread.State.NEW) {
+            stopStream();
+            createMpegTsProcessor();
+        }
+
+        stopExecutors();
+        executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(this::startStream);
+        heartbeatExecutorService = Executors.newSingleThreadScheduledExecutor();
+        heartbeatExecutorService.scheduleAtFixedRate(this::heartbeat, 5, 5, java.util.concurrent.TimeUnit.SECONDS);
+        heartbeatExecutorService.submit(this::heartbeat);
+    }
+
+    private void startStream() {
+        reportStatus("Listening on: " + connectionUrl);
+        boolean status;
+
+        var mpegts = mpegTsProcessor.get();
+
+        if (mpegts == null) {
+            logger.error("Could not start; stream processor is null");
+            return;
+        }
+        status = mpegts.openStream();
+
+        if (!status) {
+            String error = "Failed to connect to " + connectionUrl;
+            reportError(error, new SensorException(error));
+            return;
+        }
+
+        synchronized (mpegTsProcessor) {
+            mpegts = mpegTsProcessor.get();
+
+            if (mpegts == null) {
+                logger.error("Could not start; stream processor is null");
+                return;
+            }
+
+            if (mpegts.isStreamOpened()) {
+                if (mpegts.hasVideoStream()) {
+                    createVideoOutput(mpegts.getVideoStreamFrameDimensions(), mpegts.getVideoCodecName());
+                    mpegts.setVideoDataBufferListener(videoOutput.get());
+                }
+
+                if (mpegts.hasAudioStream()) {
+                    createAudioOutput(mpegts.getAudioSampleRate(), mpegts.getAudioCodecName());
+                    mpegts.setAudioDataBufferListener(audioOutput.get());
+                }
+
+            }
+            clearStatus();
+            reportStatus("RTMP stream for " + connectionUrl + " opened.");
+            hasConnected = true;
+            mpegts.processStream();
+            /*
+            executorService.submit(() -> {
+                MpegTsProcessor processor;
+                while ((processor = mpegTsProcessor.get()) != null) {
+
+                    while (processor.isStreamOpened()) {
+                        processor.processP();
+                    }
+                    if (!Thread.currentThread().isInterrupted()) {
+                        reportStatus("RTMP stream " + connectionUrl + " lost connection. Reconnecting...");
+                        processor.openStream();
+                    } else {
+                        return;
+                    }
+                }
+                reportStatus("RTMP stream closed.");
+
+            });
+
+             */
+            //mpegts.processStream();
+        }
+    }
+
+    private void heartbeat() {
+        var mpegts = mpegTsProcessor.get();
+        if (mpegts == null || !hasConnected) { return; }
+
+        if (!mpegts.isStreamOpened()) {
+            reportStatus("RTMP stream " + connectionUrl + " lost connection. Reconnecting...");
+            if (mpegts.openStream()) {
+                reportStatus("RTMP stream for " + connectionUrl + " opened.");
+            }
+        }
+    }
+
+    protected void createVideoOutput(int[] videoDims, String codecName) {
+        synchronized (videoOutput) {
+            var videoOut = new VideoOutput<>(this, videoDims, codecName);
+            videoOutput.set(videoOut);
+
+            if (videoExecutorService != null) {
+                videoExecutorService.shutdown();
+            }
+
+            videoExecutorService = Executors.newSingleThreadExecutor();
+            videoOut.setExecutor(videoExecutorService);
+            videoOut.doInit();
+            addOutput(videoOut, false);
+        }
+    }
+
+    protected void createAudioOutput(int sampleRate, String codecName) {
+        synchronized (audioOutput) {
+            var audioOut = new AudioOutput<>(this, sampleRate, codecName);
+            audioOutput.set(audioOut);
+
+            if (audioExecutorService != null) {
+                audioExecutorService.shutdown();
+            }
+            audioExecutorService = Executors.newSingleThreadExecutor();
+            audioOut.setExecutor(audioExecutorService);
+            audioOut.doInit();
+            addOutput(audioOut, false);
+        }
+    }
+
+
+    @Override
+    protected void doStop() throws SensorHubException {
+        super.doStop();
+        stopStream();
+        stopExecutors();
+        urlArbiter.removeConnection(connectionUrl);
+    }
+
+    private void stopStream() {
+        synchronized (mpegTsProcessor) {
+            var mpegts = mpegTsProcessor.get();
+            if (mpegts != null) {
+                mpegts.stopProcessingStream();
+                try {
+                    logger.info("Waiting for stream to stop.");
+                    mpegts.join(10000);
+                } catch (InterruptedException e) {
+                    logger.error("Interrupted while waiting for stream to stop.", e);
+                }
+                mpegts.closeStream();
+            }
+            mpegTsProcessor.set(null);
+        }
+    }
+
+    private void stopExecutors() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+        if (videoExecutorService != null) {
+            videoExecutorService.shutdownNow();
+        }
+        if (audioExecutorService != null) {
+            audioExecutorService.shutdownNow();
+        }
+        if (heartbeatExecutorService != null) {
+            heartbeatExecutorService.shutdownNow();
+        }
+    }
+
+
+    @Override
+    public void cleanup() throws SensorHubException {
+        super.cleanup();
+        stopStream();
+        stopExecutors();
+        urlArbiter.removeConnection(connectionUrl);
+    }
+
+    @Override
+    public boolean isConnected() {
+        return isStarted() && mpegTsProcessor.get() != null;
+    }
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
@@ -1,5 +1,12 @@
 package org.sensorhub.impl.sensor.rtmp;
+import org.bytedeco.ffmpeg.avutil.Callback_Pointer_int_BytePointer_Pointer;
+import org.bytedeco.ffmpeg.avutil.Callback_Pointer_int_String_Pointer;
+import org.bytedeco.ffmpeg.global.avcodec;
+import org.bytedeco.ffmpeg.global.avformat;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.Pointer;
 import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.api.sensor.SensorException;
 import org.sensorhub.impl.sensor.AbstractSensorModule;
 import org.sensorhub.impl.sensor.ffmpeg.outputs.AudioOutput;
@@ -7,16 +14,25 @@ import org.sensorhub.impl.sensor.ffmpeg.outputs.VideoOutput;
 import org.sensorhub.impl.sensor.rtmp.config.HostType;
 import org.sensorhub.impl.sensor.rtmp.config.RtmpConfig;
 import org.sensorhub.mpegts.MpegTsProcessor;
+import org.sensorhub.utils.Async;
 
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.bytedeco.ffmpeg.global.avutil.AV_LOG_WARNING;
+import static org.bytedeco.ffmpeg.global.avutil.av_log_set_callback;
+
 public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
-    private static final RtmpUrlArbiter urlArbiter = new RtmpUrlArbiter();
+    private static final String COMMAND_LINE_ARGS = "-timeout 0 -listen 1 -username test -password test";
+    private static final int EXECUTOR_JOIN_TIMEOUT = 10;
+    private static final TimeUnit EXECUTOR_JOIN_TIME_UNIT = TimeUnit.SECONDS;
+    private static final int HEARTBEAT_INTERVAL = 5;
+    private static final TimeUnit HEARTBEAT_TIME_UNIT = TimeUnit.SECONDS;
+    private static final int MAX_STARTUP_WAIT_TIME_MS = 5000;
+
+    private static final RtmpPortArbiter portArbiter = new RtmpPortArbiter();
     private ExecutorService executorService;
     private ExecutorService videoExecutorService;
     private ExecutorService audioExecutorService;
@@ -25,7 +41,10 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
     final AtomicReference<MpegTsProcessor> mpegTsProcessor = new AtomicReference<>();
     final AtomicReference<VideoOutput<RtmpDriver>> videoOutput = new AtomicReference<>();
     final AtomicReference<AudioOutput<RtmpDriver>> audioOutput = new AtomicReference<>();
+
+    int connectionPort = -1;
     String connectionUrl = "";
+    //String path = "";
     volatile boolean hasConnected = false;
 
 
@@ -38,29 +57,30 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
             generateXmlID("RTMP_", config.serialNumber);
         }
 
-        urlArbiter.removeConnection(connectionUrl);
+        portArbiter.removeConnection(connectionPort);
 
         setConnectionUrl();
 
-        String moduleUid;
-        if ((moduleUid = urlArbiter.addConnection(connectionUrl, this.getUniqueIdentifier())) != null) {
-            throw new SensorException("RTMP url already in use by module: " + moduleUid);
-        }
+        //createMpegTsProcessor();
+    }
 
-        createMpegTsProcessor();
+    private static String generateStreamKey() {
+        byte[] bytes = new byte[16];
+        new SecureRandom().nextBytes(bytes);
+        return HexFormat.of().formatHex(bytes);
     }
 
     private void createMpegTsProcessor() {
-        String commandLineArgs = "-timeout 0 -listen 1";
-
-        var mpegts = new MpegTsProcessor(connectionUrl, commandLineArgs);
+        var mpegts = new MpegTsProcessor(connectionUrl, COMMAND_LINE_ARGS/* + " -rtmp_app /live -rtmp_playpath " + path*/);
         mpegts.setInjectVideoExtradata(true);
         mpegTsProcessor.set(mpegts);
     }
 
     private void setConnectionUrl() throws SensorException {
+
         var connectionConfig = config.connectionConfig;
         StringBuilder sb = new StringBuilder("rtmp://");
+
 
         if (connectionConfig.host == HostType.OVERRIDE) {
             if (connectionConfig.hostOverride == null || connectionConfig.hostOverride.isBlank()) {
@@ -73,14 +93,36 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
 
         sb.append(":").append(connectionConfig.port);
 
-        if (connectionConfig.path != null && !connectionConfig.path.isBlank()) {
-            if (!connectionConfig.path.startsWith("/")) {
-                sb.append("/");
+        /*
+        if (connectionConfig.generateRandomStreamKey) {
+            connectionConfig.generateRandomStreamKey = false;
+            String streamKey = generateStreamKey();
+            if (!connectionConfig.path.isBlank() && !connectionConfig.path.endsWith("/")) {
+                connectionConfig.path += "/";
             }
-            sb.append(connectionConfig.path.trim());
+            connectionConfig.path += streamKey;
         }
 
+        if (connectionConfig.path != null && !connectionConfig.path.isBlank()) {
+            if (!connectionConfig.path.startsWith("/")) {
+                connectionConfig.path = "/" + connectionConfig.path;
+            }
+            sb.append(connectionConfig.path);
+        }
+
+        path = connectionConfig.path;
+
+         */
         connectionUrl = sb.toString();
+        connectionPort = connectionConfig.port;
+    }
+
+    @Override
+    protected void doStart() throws SensorHubException {
+        String moduleUid;
+        if ((moduleUid = portArbiter.addConnection(connectionPort, this.getUniqueIdentifier())) != null) {
+            throw new SensorException("Port "+ connectionPort + " already in use by module: " + moduleUid);
+        }
     }
 
 
@@ -90,23 +132,52 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
         //stopStream();
         hasConnected = false;
 
-        if (mpegTsProcessor.get() == null) {
-            createMpegTsProcessor();
-        } else if (mpegTsProcessor.get().getState() != Thread.State.NEW) {
-            stopStream();
+        synchronized (mpegTsProcessor) {
+            var mpegts = mpegTsProcessor.get();
+            if (mpegts != null && mpegts.getState() != Thread.State.NEW) {
+                stopStream();
+            }
             createMpegTsProcessor();
         }
 
-        stopExecutors();
+        try {
+            stopExecutors();
+        } catch (InterruptedException e) {
+            throw new SensorHubException("Interrupted while stopping executors", e);
+        }
+
+        reportStatus("Listening on: " + connectionUrl);
         executorService = Executors.newSingleThreadExecutor();
         executorService.submit(this::startStream);
         heartbeatExecutorService = Executors.newSingleThreadScheduledExecutor();
-        heartbeatExecutorService.scheduleAtFixedRate(this::heartbeat, 5, 5, java.util.concurrent.TimeUnit.SECONDS);
+        heartbeatExecutorService.scheduleAtFixedRate(this::heartbeat, HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL, HEARTBEAT_TIME_UNIT);
         heartbeatExecutorService.submit(this::heartbeat);
     }
 
+    private boolean isStopping () {
+        return getCurrentState() == ModuleEvent.ModuleState.STOPPING || getCurrentState() == ModuleEvent.ModuleState.STOPPED;
+    }
+
+    /*
+    private boolean isMatchingPath(String url) {
+        boolean isMatching = url != null && url.trim().contains(path);
+        if (!isMatching) {
+            logger.warn("Received stream on: {} but expected: {}", url, config.connectionConfig.path);
+        }
+        return isMatching;
+    }
+
+     */
+
     private void startStream() {
-        reportStatus("Listening on: " + connectionUrl);
+        // Need to wait for STARTED state so that outputs can be added
+        try {
+            Async.waitForCondition(() -> getCurrentState() == ModuleEvent.ModuleState.STARTED, MAX_STARTUP_WAIT_TIME_MS);
+        } catch (TimeoutException e) {
+            reportError("Failed to start stream; timed out waiting for startup", e);
+            return;
+        }
+
         boolean status;
 
         var mpegts = mpegTsProcessor.get();
@@ -115,7 +186,27 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
             logger.error("Could not start; stream processor is null");
             return;
         }
+
+        /*
+        // Reject connections that don't match the configured path
+        // Thread will sit here until a matching connection is made
+        do {
+            if (Thread.currentThread().isInterrupted() || isStopping()) {
+                return;
+            }
+            mpegts.closeStream();
+            status = mpegts.openStream();
+            String path = mpegts.getPrivDataString("rtmp_app") + "/" + mpegts.getPrivDataString("rtmp_playpath");
+        } while (!isMatchingPath(path));
+
+         */
+
+        mpegts.closeStream();
         status = mpegts.openStream();
+
+        if (isStopping()) {
+            return;
+        }
 
         if (!status) {
             String error = "Failed to connect to " + connectionUrl;
@@ -127,7 +218,7 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
             mpegts = mpegTsProcessor.get();
 
             if (mpegts == null) {
-                logger.error("Could not start; stream processor is null");
+                reportError("Stream could not be opened", new SensorException("MpegTs processor is null"));
                 return;
             }
 
@@ -142,6 +233,9 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
                     mpegts.setAudioDataBufferListener(audioOutput.get());
                 }
 
+            } else {
+                reportError("Stream could not be opened", new SensorException("RTMP stream connected but not opened"));
+                return;
             }
             clearStatus();
             reportStatus("RTMP stream for " + connectionUrl + " opened.");
@@ -177,9 +271,8 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
 
         if (!mpegts.isStreamOpened()) {
             reportStatus("RTMP stream " + connectionUrl + " lost connection. Reconnecting...");
-            if (mpegts.openStream()) {
-                reportStatus("RTMP stream for " + connectionUrl + " opened.");
-            }
+            createMpegTsProcessor();
+            startStream();
         }
     }
 
@@ -218,9 +311,18 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
     @Override
     protected void doStop() throws SensorHubException {
         super.doStop();
+        shutdown();
+    }
+
+    private void shutdown() throws SensorHubException {
+        portArbiter.removeConnection(config.connectionConfig.port);
         stopStream();
-        stopExecutors();
-        urlArbiter.removeConnection(connectionUrl);
+        try {
+            stopExecutors();
+        } catch (InterruptedException e) {
+            throw new SensorHubException("Interrupted while stopping executors", e);
+        }
+
     }
 
     private void stopStream() {
@@ -228,11 +330,13 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
             var mpegts = mpegTsProcessor.get();
             if (mpegts != null) {
                 mpegts.stopProcessingStream();
-                try {
-                    logger.info("Waiting for stream to stop.");
-                    mpegts.join(10000);
-                } catch (InterruptedException e) {
-                    logger.error("Interrupted while waiting for stream to stop.", e);
+                if (mpegts.isAlive()) {
+                    try {
+                        logger.info("Waiting for stream to stop.");
+                        mpegts.join();
+                    } catch (InterruptedException e) {
+                        logger.error("Interrupted while waiting for stream to stop.", e);
+                    }
                 }
                 mpegts.closeStream();
             }
@@ -240,18 +344,22 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
         }
     }
 
-    private void stopExecutors() {
+    private void stopExecutors() throws InterruptedException {
         if (executorService != null) {
             executorService.shutdownNow();
+            executorService.awaitTermination(EXECUTOR_JOIN_TIMEOUT, EXECUTOR_JOIN_TIME_UNIT);
         }
         if (videoExecutorService != null) {
             videoExecutorService.shutdownNow();
+            videoExecutorService.awaitTermination(EXECUTOR_JOIN_TIMEOUT, EXECUTOR_JOIN_TIME_UNIT);
         }
         if (audioExecutorService != null) {
             audioExecutorService.shutdownNow();
+            audioExecutorService.awaitTermination(EXECUTOR_JOIN_TIMEOUT, EXECUTOR_JOIN_TIME_UNIT);
         }
         if (heartbeatExecutorService != null) {
             heartbeatExecutorService.shutdownNow();
+            heartbeatExecutorService.awaitTermination(EXECUTOR_JOIN_TIMEOUT, EXECUTOR_JOIN_TIME_UNIT);
         }
     }
 
@@ -259,13 +367,11 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
     @Override
     public void cleanup() throws SensorHubException {
         super.cleanup();
-        stopStream();
-        stopExecutors();
-        urlArbiter.removeConnection(connectionUrl);
+        shutdown();
     }
 
     @Override
     public boolean isConnected() {
-        return isStarted() && mpegTsProcessor.get() != null;
+        return isStarted() && mpegTsProcessor.get() != null && mpegTsProcessor.get().isStreamOpened();
     }
 }

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpDriver.java
@@ -82,6 +82,7 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
         StringBuilder sb = new StringBuilder("rtmp://");
 
 
+        /*
         if (connectionConfig.host == HostType.OVERRIDE) {
             if (connectionConfig.hostOverride == null || connectionConfig.hostOverride.isBlank()) {
                 throw new SensorException("Domain override is not set");
@@ -90,6 +91,10 @@ public class RtmpDriver extends AbstractSensorModule<RtmpConfig> {
         } else {
             sb.append(connectionConfig.host.host);
         }
+
+         */
+
+        sb.append(connectionConfig.host.host);
 
         sb.append(":").append(connectionConfig.port);
 

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpPortArbiter.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpPortArbiter.java
@@ -1,15 +1,13 @@
 package org.sensorhub.impl.sensor.rtmp;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
-public class RtmpUrlArbiter {
-    private final Map<String, String> urls = new HashMap<>();
+public class RtmpPortArbiter {
+    private final Map<Integer, String> urls = new HashMap<>();
 
     // If successful, returns null, otherwise returns the moduleUid of the existing connection
-    public synchronized String addConnection(String url, String moduleUid) {
+    public synchronized String addConnection(int url, String moduleUid) {
         if (urls.containsKey(url)) {
             return urls.get(url);
         } else {
@@ -18,7 +16,7 @@ public class RtmpUrlArbiter {
         }
     }
 
-    public synchronized void removeConnection(String url) {
+    public synchronized void removeConnection(int url) {
         urls.remove(url);
     }
 }

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpUrlArbiter.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpUrlArbiter.java
@@ -1,0 +1,16 @@
+package org.sensorhub.impl.sensor.rtmp;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RtmpUrlArbiter {
+    private final Set<String> urls = new HashSet<>();
+
+    public synchronized boolean addConnection(String url) {
+        return urls.add(url);
+    }
+
+    public synchronized void removeConnection(String url) {
+        urls.remove(url);
+    }
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpUrlArbiter.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/RtmpUrlArbiter.java
@@ -1,13 +1,21 @@
 package org.sensorhub.impl.sensor.rtmp;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class RtmpUrlArbiter {
-    private final Set<String> urls = new HashSet<>();
+    private final Map<String, String> urls = new HashMap<>();
 
-    public synchronized boolean addConnection(String url) {
-        return urls.add(url);
+    // If successful, returns null, otherwise returns the moduleUid of the existing connection
+    public synchronized String addConnection(String url, String moduleUid) {
+        if (urls.containsKey(url)) {
+            return urls.get(url);
+        } else {
+            urls.put(url, moduleUid);
+            return null;
+        }
     }
 
     public synchronized void removeConnection(String url) {

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/ConnectionConfig.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/ConnectionConfig.java
@@ -1,0 +1,24 @@
+package org.sensorhub.impl.sensor.rtmp.config;
+
+import org.sensorhub.api.config.DisplayInfo;
+
+public class ConnectionConfig {
+
+    @DisplayInfo.Required
+    @DisplayInfo(label = "Host", desc = "Domain listening for an RTMP connection request. Unspecified should work " +
+    "for most cases.")
+    public HostType host = HostType.UNSPECIFIED;
+
+    @DisplayInfo(label = "Host Override", desc = "(Optional) Override the host listening for an RTMP connection request."
+    + "\nHost must be set to OVERRIDE.")
+    public String hostOverride = "";
+
+    @DisplayInfo.Required
+    @DisplayInfo(label = "Port", desc = "Port listening for an RTMP connection request.")
+    @DisplayInfo.ValueRange(min = 1, max = 65535)
+    public int port = 1935;
+
+    @DisplayInfo(label = "Path", desc = "(Optional) Path to listen for an RTMP connection request. I.e. everything in the URL " +
+    "after the port.")
+    public String path = "";
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/ConnectionConfig.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/ConnectionConfig.java
@@ -4,6 +4,14 @@ import org.sensorhub.api.config.DisplayInfo;
 
 public class ConnectionConfig {
 
+    /*
+    @DisplayInfo.Required
+    @DisplayInfo(label = "Generate Random Stream Key", desc = "Enable to generate and append a random hex string to the path. " +
+            "Recommended for security. Only enable on first init, otherwise path will include multiple keys. ")
+    public boolean generateRandomStreamKey = true;
+
+     */
+
     @DisplayInfo.Required
     @DisplayInfo(label = "Host", desc = "Domain listening for an RTMP connection request. Unspecified should work " +
     "for most cases.")
@@ -18,7 +26,10 @@ public class ConnectionConfig {
     @DisplayInfo.ValueRange(min = 1, max = 65535)
     public int port = 1935;
 
+    /*
     @DisplayInfo(label = "Path", desc = "(Optional) Path to listen for an RTMP connection request. I.e. everything in the URL " +
     "after the port.")
     public String path = "";
+    
+     */
 }

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/ConnectionConfig.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/ConnectionConfig.java
@@ -17,10 +17,6 @@ public class ConnectionConfig {
     "for most cases.")
     public HostType host = HostType.UNSPECIFIED;
 
-    @DisplayInfo(label = "Host Override", desc = "(Optional) Override the host listening for an RTMP connection request."
-    + "\nHost must be set to OVERRIDE.")
-    public String hostOverride = "";
-
     @DisplayInfo.Required
     @DisplayInfo(label = "Port", desc = "Port listening for an RTMP connection request.")
     @DisplayInfo.ValueRange(min = 1, max = 65535)
@@ -30,6 +26,6 @@ public class ConnectionConfig {
     @DisplayInfo(label = "Path", desc = "(Optional) Path to listen for an RTMP connection request. I.e. everything in the URL " +
     "after the port.")
     public String path = "";
-    
+
      */
 }

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/HostType.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/HostType.java
@@ -1,0 +1,14 @@
+package org.sensorhub.impl.sensor.rtmp.config;
+
+public enum HostType {
+    UNSPECIFIED("0.0.0.0"),
+    LOCALHOST("localhost"),
+    DOCKER_INTERNAL("host.docker.internal"),
+    OVERRIDE("");
+
+    public final String host;
+
+    HostType(String host) {
+        this.host = host;
+    }
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/HostType.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/HostType.java
@@ -3,8 +3,8 @@ package org.sensorhub.impl.sensor.rtmp.config;
 public enum HostType {
     UNSPECIFIED("0.0.0.0"),
     LOCALHOST("localhost"),
-    DOCKER_INTERNAL("host.docker.internal"),
-    OVERRIDE("");
+    DOCKER_INTERNAL("host.docker.internal")/*,
+    OVERRIDE("")*/;
 
     public final String host;
 

--- a/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/RtmpConfig.java
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/java/org/sensorhub/impl/sensor/rtmp/config/RtmpConfig.java
@@ -1,0 +1,31 @@
+package org.sensorhub.impl.sensor.rtmp.config;
+
+import org.sensorhub.api.config.DisplayInfo;
+import org.sensorhub.api.sensor.PositionConfig;
+import org.sensorhub.api.sensor.SensorConfig;
+
+public class RtmpConfig extends SensorConfig {
+    @DisplayInfo.Required
+    @DisplayInfo(label = "Video Stream ID", desc = "Serial number or unique identifier for video stream.")
+    public String serialNumber = "video001";
+
+    @DisplayInfo.Required
+    @DisplayInfo(label = "Connection", desc = "Configuration options for source of RTMP.")
+    public ConnectionConfig connectionConfig = new ConnectionConfig();
+
+    /**
+     * Configuration options for the location and orientation of the sensor.
+     */
+    @DisplayInfo(label = "Position", desc = "Location and orientation of the sensor.")
+    public PositionConfig positionConfig = new PositionConfig();
+
+    @Override
+    public PositionConfig.LLALocation getLocation() {
+        return positionConfig.location;
+    }
+
+    @Override
+    public PositionConfig.EulerOrientation getOrientation() {
+        return positionConfig.orientation;
+    }
+}

--- a/sensors/video/sensorhub-driver-rtmp/src/main/resources/META-INF/services/org.sensorhub.api.module.IModuleProvider
+++ b/sensors/video/sensorhub-driver-rtmp/src/main/resources/META-INF/services/org.sensorhub.api.module.IModuleProvider
@@ -1,0 +1,1 @@
+org.sensorhub.impl.sensor.rtmp.RtmpDescriptor


### PR DESCRIPTION
Specialized FFmpeg sensor driver implementation to listen for and demux RTMP streams. 

Note: FFmpeg's RTMP listener implementation currently do not check user credentials or the RTMP app/playpath. These features are being researched and may be added in the future. 

Additionally, this PR also makes some small changes to the FFmpeg sensor MpegTsProcessor class. These changes are unlikely to break anything, but it may be worth testing.

**Testing:**

**Listening Test**
1. Create an RTMP driver.
2. In Connection, leave port as 1935 (or change to any other value if the port is in use by another app).
3. Set the host to LOCALHOST. If testing with an external RTMP source, set the host to UNSPECIFIED.
4. Initialize and start the driver. The driver's status should state that it is listening.
5. Start the RTMP publish. After a moment, the driver status should state that the stream has opened.
6. Stop the RTMP publish (but leave the driver running). The driver status should state that the connection has been lost.
7. Start the RTMP publish again. The driver status should update to state that the stream has opened.
8. Stop the RTMP publish and driver (in either order). Verify that there is no error status in the admin panel.

**Port Check Test**
1. Create an RTMP driver and start it.
2. Create another RTMP driver with the same port and attempt to start it. The driver should not be started. A status message should identify the other RTMP driver currently using the port.

**Setting up a local RTMP publisher:**

With FFmpeg, run the following command in a separate terminal to start publishing RTMP:
`ffmpeg -re -stream_loop -1 -i "[source video file or url]" -f flv "rtmp://localhost:1935"` 